### PR TITLE
Support/wagtail 51

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
--
+- Added support Wagtail 5.1 (by @lparsons396)
 
 ## [0.2.0] - 2023-07-31
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Integrates [django-admin-rangefilter](https://pypi.org/project/django-admin-rang
 
 - Python 3.8, 3.9, 3.10, 3.11
 - Django 3.2, 4.1, 4.2
-- Wagtail 4.1, 4.2, 5.0
+- Wagtail 4.1, 4.2, 5.0, 5.1
 
 ## Installation
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ skipsdist = True
 usedevelop = True
 
 envlist =
-    python{3.8,3.9,3.10}-django{3.2,4.1}-wagtail{4.1,4.2,main}-{sqlite,postgres}
-    python{3.11}-django{4.1,4.2}-wagtail{5.0,main}-{sqlite,postgres}
+    python{3.8,3.9,3.10}-django{3.2,4.1}-wagtail{4.1,4.2,5.0,5.1,main}-{sqlite,postgres}
+    python{3.11}-django{4.1,4.2}-wagtail{5.0,5.1,main}-{sqlite,postgres}
     flake8
 
 [flake8]
@@ -42,6 +42,7 @@ deps =
     wagtail4.1: wagtail>=4.1,<4.2
     wagtail4.2: wagtail>=4.2,<5.0
     wagtail5.0: wagtail>=5.0,<5.1
+    wagtail5.1: wagtail>=5.1,<5.2
     wagtailmain: git+https://github.com/wagtail/wagtail.git
 
     postgres: psycopg2>=2.6


### PR DESCRIPTION
- Supports Wagtail 5.1

NB: this is to flag that `wagtail.contrib.modeladmin` is due to be deprecated - see https://docs.wagtail.org/en/stable/releases/5.1.html#wagtail-contrib-modeladmin-is-deprecated for upgrade suggestions