### PR TITLE
Support/wagtail 52

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Added support Wagtail 5.1 (by @lparsons396)
+- Added support Wagtail 5.1, 5.2 (by @lparsons396, @katdom13)
+- Drop tests for Wagtail 4.2, 5.0 as they have reached EOL (@katdom13)
 
 ## [0.2.0] - 2023-07-31
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,9 @@ skipsdist = True
 usedevelop = True
 
 envlist =
-    python{3.8,3.9,3.10}-django{3.2,4.1}-wagtail{4.1,4.2,5.0,5.1}-{sqlite,postgres}
-    python{3.11}-django{4.1,4.2}-wagtail{5.0,5.1}-{sqlite,postgres}
+    python{3.8,3.9,3.10}-django{3.2,4.1}-wagtail{4.1,5.1,5.2}-{sqlite,postgres}
+    python3.11-django4.1-wagtail{4.1,5.1,5.2}-{sqlite,postgres}
+    python3.11-django4.2-wagtail{5.1,5.2}-{sqlite,postgres}
     flake8
 
 [flake8]


### PR DESCRIPTION
## [Wagtail 5.2 release notes](https://docs.wagtail.org/en/stable/releases/5.2.html)

### Changes

- Update test matrices
- Drop tests for Wagtail 4.2 and 5.0 as they have reached EOL