### PR TITLE
Wagtail 6.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,12 +15,12 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Tox
@@ -42,9 +42,9 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Tox

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
--
+- Drop tests for Wagtail < 5.2 as they have reached EOL (@katdom13)
+- Drop tests for Django 4.1 as it has reached EOL (@katdom13)
+- Add tests for Python 3.12 (@katdom13)
+- Add `wagtail-modeladmin` to testing dependencies (@katdom13)
 
 ## [0.2.1] - 2024-02-07
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Integrates [django-admin-rangefilter](https://pypi.org/project/django-admin-rang
 
 ## Supported versions
 
-- Python 3.8, 3.9, 3.10, 3.11
-- Django 3.2, 4.2
-- Wagtail 4.1, 5.1, 5.2, 6.0 (with external package [wagtail-modeladmin](https://pypi.org/project/wagtail-modeladmin/))
+- Python 3.8, 3.9, 3.10, 3.11, 3.12
+- Django 3.2, 4.2, 5.0
+- Wagtail 5.2, 6.0 (with external package [wagtail-modeladmin](https://pypi.org/project/wagtail-modeladmin/))
 
 ## Installation
 
@@ -41,9 +41,7 @@ INSTALLED_APPS = [
 ## Example usage
 
 ```python
-# Starting with Wagtail 6.0, the external package "wagtail-modeladmin" is required:
-# from wagtail_modeladmin.options import ModelAdmin
-from wagtail.contrib.modeladmin.options import ModelAdmin
+from wagtail_modeladmin.options import ModelAdmin
 from wagtail_rangefilter.filters import DateRangeFilter, DateTimeRangeFilter
 
 class ExampleAdmin(ModelAdmin):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,11 +22,11 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Framework :: Django",
     "Framework :: Django :: 3.2",
-    "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
+    "Framework :: Django :: 5.0",
     "Framework :: Wagtail",
-    "Framework :: Wagtail :: 4",
     "Framework :: Wagtail :: 5",
+    "Framework :: Wagtail :: 6",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
@@ -36,18 +36,20 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 requires-python = ">=3.8"
 dependencies = [
     "django-admin-rangefilter>=0.12",
     "Django>=3.2",
-    "wagtail>=4.1",
+    "wagtail>=5.2",
 ]
 
 [project.optional-dependencies]
 testing = [
     "coverage~=6.4.4",
     "tox~=3.26.0",
+    "wagtail-modeladmin==2.0.0",
 ]
 
 [project.urls]

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -22,12 +22,6 @@ ALLOWED_HOSTS = ["*"]
 
 
 # Application definition
-try:
-    import wagtail_modeladmin
-except ImportError:
-    modeladmin_package_name = "wagtail.contrib.modeladmin"
-else:
-    modeladmin_package_name = "wagtail_modeladmin"
 
 INSTALLED_APPS = [
     "tests.testapp",
@@ -44,7 +38,7 @@ INSTALLED_APPS = [
     "wagtail.search",
     "wagtail.admin",
     "wagtail.api.v2",
-    modeladmin_package_name,
+    "wagtail_modeladmin",
     "wagtail.contrib.routable_page",
     "wagtail.contrib.styleguide",
     "wagtail.sites",

--- a/tests/testapp/wagtail_hooks.py
+++ b/tests/testapp/wagtail_hooks.py
@@ -1,7 +1,4 @@
-try:
-    from wagtail_modeladmin.options import ModelAdmin, modeladmin_register
-except ImportError:
-    from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
+from wagtail_modeladmin.options import ModelAdmin, modeladmin_register
 
 from wagtail_rangefilter.filters import DateRangeFilter, DateTimeRangeFilter
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,9 @@ skipsdist = True
 usedevelop = True
 
 envlist =
-    python{3.8,3.9,3.10,3.11}-django3.2-wagtail{4.1,5.1,5.2}-{sqlite,postgres}
-    python3.11-django4.2-wagtail{5.1,5.2,6.0}-{sqlite,postgres}
+    python{3.8,3.9,3.10}-django3.2-wagtail5.2
+    python{3.8,3.9,3.10,3.11}-django4.2-wagtail{5.2,6.0}
+    python{3.11,3.12}-django5.0-wagtail{5.2,6.0}
     flake8
 
 [flake8]
@@ -28,32 +29,24 @@ basepython =
     python3.9: python3.9
     python3.10: python3.10
     python3.11: python3.11
+    python3.12: python3.12
 
 deps =
     coverage
 
     django3.2: Django>=3.2,<4.0
     django4.2: Django>=4.2,<4.3
-
-    ; The current Django version for main is 5.x, which is not supported by any Wagtail versions yet
+    django5.0: Django>=5.0,<5.1
     djangomain: git+https://github.com/django/django.git@main#egg=Django
 
-    wagtail4.1: wagtail>=4.1,<4.2
-    wagtail5.1: wagtail>=5.1,<5.2
     wagtail5.2: wagtail>=5.2,<5.3
-
-    ; Starting with wagtail 6.0 the wagtail.contrib.modeladmin module has been removed.
-    ; TODO: replace wagtail==6.0rc1 with wagtail>=6.0,<6.1 when wagtail 6.0 gets released
-    wagtail6.0: wagtail==6.0rc1
-    wagtail6.0: wagtail-modeladmin
-
+    wagtail6.0: wagtail>=6.0,<6.1
     wagtailmain: git+https://github.com/wagtail/wagtail.git
-    wagtailmain: wagtail-modeladmin
 
     postgres: psycopg2>=2.6
 
 [testenv:interactive]
-basepython = python3.10
+basepython = python3.12
 
 commands_pre =
     python {toxinidir}/manage.py makemigrations
@@ -68,7 +61,7 @@ setenv =
     INTERACTIVE = 1
 
 [testenv:flake8]
-basepython=python3.7
+basepython=python3.12
 deps=flake8>=2.2.0
 commands=flake8 src/wagtail_rangefilter tests/
 
@@ -78,6 +71,7 @@ python =
     3.9: python3.9
     3.10: python3.10
     3.11: python3.11
+    3.12: python3.12
 
 [gh-actions:env]
 DB_BACKEND =


### PR DESCRIPTION
[Support Ticket](https://torchbox.monday.com/boards/1124794299/pulses/1396935681)

## [Wagtail 6.0 release notes](https://docs.wagtail.org/en/stable/releases/6.0.html)

### Summary of changes

- Drop tests for Wagtail < 5.2 as they have reached EOL (@katdom13)
- Drop tests for Django 4.1 as it has reached EOL (@katdom13)
- Add tests for Python 3.12 (@katdom13)
- Add `wagtail-modeladmin` to testing dependencies (@katdom13)